### PR TITLE
feat: container build workflow

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,69 @@
+name: Build and push container image
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'spotted-cesium-viewer-v*.*.*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            # match release-please manifest driven release tag format
+            # https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
+            type=match,pattern=.*-v(\d+.\d+.\d+),group=1
+            type=match,pattern=.*-v(\d+.\d+),group=1
+            type=match,pattern=.*-v(\d+),group=1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DOCKER_META_VERSION=${{ steps.meta.outputs.version }}
+            DOCKER_META_TITLE=${{ steps.meta.outputs.title }}
+            DOCKER_META_VERSION_SEMVER=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            DOCKER_META_REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow for building and pushing container images to GitHub Container Registry (ghcr.io).

The workflow is triggered on pushes to the `main` branch and tags matching the pattern `lido-visualisations-v*.*.*`.

It performs the following steps:

- Extracts Docker metadata using the `docker/metadata-action` action.
- Sets up QEMU for cross-platform builds.
- Sets up Docker Buildx for multi-platform builds.
- Logs into ghcr.io using the `docker/login-action` action.
- Builds and pushes the Docker image using the `docker/build-push-action` action.

The image is built for both `linux/amd64` and `linux/arm64` platforms.

The commit also includes several build arguments for setting the Docker image version, title, semantic version, and revision. It also allows setting Sentry-related secrets as build arguments.

The workflow uses GitHub Actions cache for caching Docker layers.

It also generates SBOM and provenance attestations.