### PR TITLE
ci: migrate release-please to GitHub App token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,5 +9,7 @@ on:
 jobs:
   release-please:
     uses: ForumViriumHelsinki/.github/.github/workflows/reusable-release-please.yml@main
+    with:
+      app-id: ${{ vars.CI_APP_ID }}
     secrets:
-      MY_RELEASE_PLEASE_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+      APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

The org PAT `MY_RELEASE_PLEASE_TOKEN` expired, failing release-please with `Bad credentials` on push to the default branch.

## Fix

Switch release-please auth to the GitHub App token (`CI_APP_ID` + `CI_APP_PRIVATE_KEY`), matching the `infrastructure` repo's working pattern. App tokens don't expire like the PAT.

Part of an org-wide PAT→App migration sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)